### PR TITLE
add support for custom/unknown type tags

### DIFF
--- a/src/edn_formatter/content.cljs
+++ b/src/edn_formatter/content.cljs
@@ -6,6 +6,10 @@
    [edn-formatter.util :refer [background?]]
    [edn-formatter.css :as css]))
 
+(reader/register-default-tag-parser!
+  (fn [tag value]
+    (str tag "# " value)))
+
 (defn div [id]
   (let [el (js/document.createElement "div")]
     (set! (.-id el) id)


### PR DESCRIPTION
This change prevents a parse error when encountering custom or unknown type tags in EDN payloads. It displays them simply using the tag and value.
